### PR TITLE
[Win32] Fix race condition in PartyNetworkSampleCommon NetworkManager

### DIFF
--- a/win32/PartySample/PartySampleNetworkCommon/inc/NetworkManager.h
+++ b/win32/PartySample/PartySampleNetworkCommon/inc/NetworkManager.h
@@ -106,7 +106,37 @@ namespace PartySample
         void setTextToSpeechProfile();
         bool isTranslationInTheLocalLanguage(Party::PartyTranslation translation);
         std::string findExpectedTranslation(Party::PartyTranslation* translations, int translationCount);
+
         void ProcessChatIndicatorUpdates();
+
+        void HandlePlayerJoined(
+            const std::string& newPlayerEntityId,
+            const std::string& newPlayerDisplayName
+            );
+
+        void HandleIncomingTextMessage(
+            const std::string& senderPlayerEntityId,
+            const std::string& message
+            );
+
+        void HandleIncomingVoiceTranscription(
+            const std::string& senderPlayerEntityId,
+            const std::string& transcription
+            );
+
+        void HandleLocalChatIndicatorUpdate(
+            const std::string& localPlayerEntityId,
+            Party::PartyLocalChatControlChatIndicator chatIndicator
+            );
+
+        void HandleRemoteChatIndicatorUpdate(
+            const std::string& remotePlayerEntityId,
+            Party::PartyChatControlChatIndicator chatIndicator
+            );
+
+        void HandlePlayerLeft(
+            const std::string& playerEntityId
+            );
 
         std::function<void(std::string)> m_onNetworkCreated;
         std::function<void(PartyError)> m_onNetworkCreatedError;
@@ -129,6 +159,9 @@ namespace PartySample
         std::atomic_bool m_ttsProfileNeedsUpdate;
         std::mutex m_networkLock;
         float m_renderVolume;
+
+        // These players have (1) Joined the network and (2) sent their display name to other players
+        std::set<std::string> m_remotePlayers;
 
         // PlayFab Party is responsive enough that a UI which can handle frequent updates can poll for the chat
         // indicators every frame. Since this code is shared across a number of UI frameworks, we'll cache the chat

--- a/win32/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
+++ b/win32/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
@@ -937,7 +937,7 @@ NetworkManager::DoWork()
                 // Send the current users display name to the other chat controls.
                 const std::string& displayName = Managers::Get<PlayFabManager>()->displayName();
                 PartyEndpoint* newRemoteEndpoint = result->endpoint;
-                // FIXME: tmp SendNetworkMessage(1, &newRemoteEndpoint, NetworkMessage { NetworkMessageType::UserDisplayName, displayName });
+                SendNetworkMessage(1, &newRemoteEndpoint, NetworkMessage { NetworkMessageType::UserDisplayName, displayName });
             }
             else
             {

--- a/win32/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
+++ b/win32/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
@@ -937,7 +937,7 @@ NetworkManager::DoWork()
                 // Send the current users display name to the other chat controls.
                 const std::string& displayName = Managers::Get<PlayFabManager>()->displayName();
                 PartyEndpoint* newRemoteEndpoint = result->endpoint;
-                SendNetworkMessage(1, &newRemoteEndpoint, NetworkMessage { NetworkMessageType::UserDisplayName, displayName });
+                // FIXME: tmp SendNetworkMessage(1, &newRemoteEndpoint, NetworkMessage { NetworkMessageType::UserDisplayName, displayName });
             }
             else
             {

--- a/win32/PartySample/PartySampleNetworkCommon/lib/pch.h
+++ b/win32/PartySample/PartySampleNetworkCommon/lib/pch.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <queue>
 #include <errno.h>
+#include <set>
 
 //Include platform specific definitions
 #if defined(__ANDROID__) || defined(__APPLE__)

--- a/win32/PartySample/dll/pch.h
+++ b/win32/PartySample/dll/pch.h
@@ -12,6 +12,7 @@
 #include <thread>
 #include <mutex>
 #include <vector>
+#include <set>
 
 // External dependencies
 #include <Party.h>


### PR DESCRIPTION
The shared NetworkManager component which drives the interaction with PlayFab Party logic in the Party Chat Sample app had a race condition where a remote player might send messages or otherwise interact with the local player before they had finished sending the initial message which announces their displayname and is used as the first signal that a remote chat player has fully joined the network.

This PR fixes that race condition by keeping track of which players have joined and not firing callbacks for unknown players.

This change is made in the NetworkManager component rather than in platform-specific App layer so that it can be (eventually) reused across platforms once all of the samples are restructured to use the same core sample code