### PR TITLE
implemented pause and resume feature on iOS PartySample

### DIFF
--- a/iOS/PartySample/app/inc/ChatEventHandler.h
+++ b/iOS/PartySample/app/inc/ChatEventHandler.h
@@ -11,6 +11,7 @@
 @protocol ChatEventHandler
 
 -(void) onNetworkCreated:(NSString*) networkDescriptor;
+-(void) onGetDescriptorCompleted:(NSString*) networkId withNetworkDescriptor:(NSString*) networkDescriptor;
 -(void) onJoinedNetwork;
 -(void) onPlayerJoin:(NSString*) userId;
 -(void) onPlayerLeft:(NSString*) userId;

--- a/iOS/PartySample/app/inc/SimpleClient.h
+++ b/iOS/PartySample/app/inc/SimpleClient.h
@@ -11,9 +11,24 @@
 #import <Foundation/Foundation.h>
 #import "ChatEventHandler.h"
 
-@interface SimpleClient : NSObject
+@class NotificationReceiver;
+
+@protocol NotificationReceiver
+
+- (void)didEnterBackground;
+- (void)willEnterForeground;
+
+@end
+
+@interface SimpleClient : NSObject <ChatEventHandler, NotificationReceiver> {
+    NSString* _networkId;
+    NSString* _networkDescriptor;
+
+}
 
 @property (nonatomic) id<ChatEventHandler> chatEventHandler;
+
+@property (nonatomic)  NotificationReceiver *notificationReceiver;
 
 -(void) initialize:(NSString*)pfTitle;
 -(void) setHandler:(id<ChatEventHandler>) messageHandler;

--- a/iOS/PartySample/app/src/AppDelegate.m
+++ b/iOS/PartySample/app/src/AppDelegate.m
@@ -30,11 +30,13 @@
 - (void)applicationDidEnterBackground:(UIApplication *)application {
     // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
     // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"PartySample.DidEnterBackground" object:nil];
 }
 
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
     // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"PartySample.WillEnterForeground" object:nil];
 }
 
 

--- a/iOS/PartySample/app/src/ChatViewController.m
+++ b/iOS/PartySample/app/src/ChatViewController.m
@@ -255,6 +255,11 @@ SimpleClient* m_client;
     [self updateButtonStatus:YES];
 }
 
+-(void) onGetDescriptorCompleted:(NSString*) networkId withNetworkDescriptor:(NSString*) networkDescriptor
+{
+    
+}
+
 -(void) onJoinedNetwork
 {
     [self updateButtonStatus:YES];

--- a/iOS/PartySample/app/src/ChatViewController.m
+++ b/iOS/PartySample/app/src/ChatViewController.m
@@ -257,7 +257,6 @@ SimpleClient* m_client;
 
 -(void) onGetDescriptorCompleted:(NSString*) networkId withNetworkDescriptor:(NSString*) networkDescriptor
 {
-    
 }
 
 -(void) onJoinedNetwork

--- a/iOS/PartySample/app/src/SimpleClientImpl.cpp
+++ b/iOS/PartySample/app/src/SimpleClientImpl.cpp
@@ -178,6 +178,8 @@ SimpleClientImpl::ConnectToNetwork(
     bool rejoining
     )
 {
+    Managers::Get<NetworkManager>()->Initialize(g_pfTitle.c_str());
+    m_messageHandler->OnStartLoading();
     Managers::Get<NetworkManager>()->ConnectToNetwork(
         networkId.c_str(),
         message.c_str(),
@@ -420,10 +422,17 @@ exit:
     m_messageHandler->OnPlayerStatusUpdateEnd();
 }
 
+static void PipeErrorSignalHandler(int sig_num)
+{
+    /* re-set the signal handler again to catch_int, for next time */
+    signal(SIGPIPE, PipeErrorSignalHandler);
+}
+
 void
 SimpleClientImpl::GlobalInitialize()
 {
     // Add intialization tasks here
+    signal(SIGPIPE, PipeErrorSignalHandler);
 }
 
 void


### PR DESCRIPTION
This PR implements the Pause and Resume feature on iOS.
This change is for showing how the customer disconnect from network when their app enters the background and reconnects to the previous network when the app later switches back to the foreground.

The basic mechanism are:
1. App stores the Network ID and Network Descriptor when the app is connected to the party network. 
2. When the iOS calls the entering background delegate interface in the App, it posts the notification to the module which is waiting that notification.
3. The module closes the connection and shutdown Party library. 
4. When the app is switched to the foreground, the module receives notification in the same way as before.
5. The App checks the previous Network ID and Network Descriptor is populated, and  the App tries to connect to the previous network with previous network information.

It will not reconnect previous network if the user leaves the network intentionally because the app clean up the network information when the user select leave button.
