### PR TITLE
Enable mixed-mode debugging by default for sample app on  Win32 platforms

### DIFF
--- a/win32/PartySample/gui/PartySampleGui.csproj
+++ b/win32/PartySample/gui/PartySampleGui.csproj
@@ -29,6 +29,7 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
This is a small change to the VS project files for the "PartySampleGui" project in the Win32 PartySample app to enable "mixed mode" debugging by default.

This is important because currently when launching the sample app for debugging, its configuration means that the debugger only hooks into our managed C# code. This is basically just the UI and would likely be of little use to any dev wanting to use the PartySample app to get an understanding of how to interface with the Party API.

By enabling "mixed-mode" debugging by default, this change means that the debugger will now automatically hook into both managed (C#) and unmanaged (C++) code in the project and make it much easier for someone to just jump in and start poking around.