### PR TITLE
Remove using of c_maxNetworkConfigurationMaxDeviceCount constant in sample

### DIFF
--- a/android/PartySampleNetworkCommon/lib/NetworkManager.cpp
+++ b/android/PartySampleNetworkCommon/lib/NetworkManager.cpp
@@ -166,13 +166,16 @@ NetworkManager::CreateAndConnectToNetwork(
 {
     DEBUGLOG("NetworkManager::CreateAndConnectToNetwork()\n");
 
+    // Arbitrarily support 16 max devices for the sample since this is usually the most that games need
+    constexpr uint8_t c_maxSampleNetworkDeviceCount = 16;
+    static_assert(c_maxSampleNetworkDeviceCount <= c_maxNetworkConfigurationMaxDeviceCount, "Must be less than or equal to c_maxNetworkConfigurationMaxDeviceCount.");
+
     PartyNetworkConfiguration cfg = {};
 
-    // Set up the network to allow 29 single-device players of any device type
-    cfg.maxDeviceCount = 29;
+    cfg.maxDeviceCount = c_maxSampleNetworkDeviceCount;
     cfg.maxDevicesPerUserCount = 1;
     cfg.maxEndpointsPerDeviceCount = 1;
-    cfg.maxUserCount = 29;
+    cfg.maxUserCount = c_maxSampleNetworkDeviceCount;
     cfg.maxUsersPerDeviceCount = 1;
 
     //Get the uid from the local chat control

--- a/android/PartySampleNetworkCommon/lib/NetworkManager.cpp
+++ b/android/PartySampleNetworkCommon/lib/NetworkManager.cpp
@@ -168,7 +168,7 @@ NetworkManager::CreateAndConnectToNetwork(
 
     PartyNetworkConfiguration cfg = {};
 
-    // Setup the network to allow the maximum number of single-device players of any device type
+    // Set up the network to allow 29 single-device players of any device type
     cfg.maxDeviceCount = 29;
     cfg.maxDevicesPerUserCount = 1;
     cfg.maxEndpointsPerDeviceCount = 1;

--- a/android/PartySampleNetworkCommon/lib/NetworkManager.cpp
+++ b/android/PartySampleNetworkCommon/lib/NetworkManager.cpp
@@ -169,10 +169,10 @@ NetworkManager::CreateAndConnectToNetwork(
     PartyNetworkConfiguration cfg = {};
 
     // Setup the network to allow the maximum number of single-device players of any device type
-    cfg.maxDeviceCount = c_maxNetworkConfigurationMaxDeviceCount;
+    cfg.maxDeviceCount = 29;
     cfg.maxDevicesPerUserCount = 1;
     cfg.maxEndpointsPerDeviceCount = 1;
-    cfg.maxUserCount = c_maxNetworkConfigurationMaxDeviceCount;
+    cfg.maxUserCount = 29;
     cfg.maxUsersPerDeviceCount = 1;
 
     //Get the uid from the local chat control

--- a/iOS/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
+++ b/iOS/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
@@ -166,13 +166,16 @@ NetworkManager::CreateAndConnectToNetwork(
 {
     DEBUGLOG("NetworkManager::CreateAndConnectToNetwork()\n");
 
+    // Arbitrarily support 16 max devices for the sample since this is usually the most that games need
+    constexpr uint8_t c_maxSampleNetworkDeviceCount = 16;
+    static_assert(c_maxSampleNetworkDeviceCount <= c_maxNetworkConfigurationMaxDeviceCount, "Must be less than or equal to c_maxNetworkConfigurationMaxDeviceCount.");
+
     PartyNetworkConfiguration cfg = {};
 
-    // Set up the network to allow 29 single-device players of any device type
-    cfg.maxDeviceCount = 29;
+    cfg.maxDeviceCount = c_maxSampleNetworkDeviceCount;
     cfg.maxDevicesPerUserCount = 1;
     cfg.maxEndpointsPerDeviceCount = 1;
-    cfg.maxUserCount = 29;
+    cfg.maxUserCount = c_maxSampleNetworkDeviceCount;
     cfg.maxUsersPerDeviceCount = 1;
 
     //Get the uid from the local chat control

--- a/iOS/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
+++ b/iOS/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
@@ -168,7 +168,7 @@ NetworkManager::CreateAndConnectToNetwork(
 
     PartyNetworkConfiguration cfg = {};
 
-    // Setup the network to allow the maximum number of single-device players of any device type
+    // Set up the network to allow 29 single-device players of any device type
     cfg.maxDeviceCount = 29;
     cfg.maxDevicesPerUserCount = 1;
     cfg.maxEndpointsPerDeviceCount = 1;

--- a/iOS/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
+++ b/iOS/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
@@ -169,10 +169,10 @@ NetworkManager::CreateAndConnectToNetwork(
     PartyNetworkConfiguration cfg = {};
 
     // Setup the network to allow the maximum number of single-device players of any device type
-    cfg.maxDeviceCount = c_maxNetworkConfigurationMaxDeviceCount;
+    cfg.maxDeviceCount = 29;
     cfg.maxDevicesPerUserCount = 1;
     cfg.maxEndpointsPerDeviceCount = 1;
-    cfg.maxUserCount = c_maxNetworkConfigurationMaxDeviceCount;
+    cfg.maxUserCount = 29;
     cfg.maxUsersPerDeviceCount = 1;
 
     //Get the uid from the local chat control

--- a/win32/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
+++ b/win32/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
@@ -166,13 +166,16 @@ NetworkManager::CreateAndConnectToNetwork(
 {
     DEBUGLOG("NetworkManager::CreateAndConnectToNetwork()\n");
 
+    // Arbitrarily support 16 max devices for the sample since this is usually the most that games need
+    constexpr uint8_t c_maxSampleNetworkDeviceCount = 16;
+    static_assert(c_maxSampleNetworkDeviceCount <= c_maxNetworkConfigurationMaxDeviceCount, "Must be less than or equal to c_maxNetworkConfigurationMaxDeviceCount.");
+
     PartyNetworkConfiguration cfg = {};
 
-    // Set up the network to allow 29 single-device players of any device type
-    cfg.maxDeviceCount = 29;
+    cfg.maxDeviceCount = c_maxSampleNetworkDeviceCount;
     cfg.maxDevicesPerUserCount = 1;
     cfg.maxEndpointsPerDeviceCount = 1;
-    cfg.maxUserCount = 29;
+    cfg.maxUserCount = c_maxSampleNetworkDeviceCount;
     cfg.maxUsersPerDeviceCount = 1;
 
     //Get the uid from the local chat control

--- a/win32/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
+++ b/win32/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
@@ -168,7 +168,7 @@ NetworkManager::CreateAndConnectToNetwork(
 
     PartyNetworkConfiguration cfg = {};
 
-    // Setup the network to allow the maximum number of single-device players of any device type
+    // Set up the network to allow 29 single-device players of any device type
     cfg.maxDeviceCount = 29;
     cfg.maxDevicesPerUserCount = 1;
     cfg.maxEndpointsPerDeviceCount = 1;

--- a/win32/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
+++ b/win32/PartySample/PartySampleNetworkCommon/lib/NetworkManager.cpp
@@ -169,10 +169,10 @@ NetworkManager::CreateAndConnectToNetwork(
     PartyNetworkConfiguration cfg = {};
 
     // Setup the network to allow the maximum number of single-device players of any device type
-    cfg.maxDeviceCount = c_maxNetworkConfigurationMaxDeviceCount;
+    cfg.maxDeviceCount = 29;
     cfg.maxDevicesPerUserCount = 1;
     cfg.maxEndpointsPerDeviceCount = 1;
-    cfg.maxUserCount = c_maxNetworkConfigurationMaxDeviceCount;
+    cfg.maxUserCount = 29;
     cfg.maxUsersPerDeviceCount = 1;
 
     //Get the uid from the local chat control


### PR DESCRIPTION
Remove using of c_maxNetworkConfigurationMaxDeviceCount constant from sample code when creating Party network.